### PR TITLE
Removed Max Users field from Group

### DIFF
--- a/client/src/pages/manager/GroupsPage.jsx
+++ b/client/src/pages/manager/GroupsPage.jsx
@@ -107,7 +107,6 @@ const GroupsPage = () => {
                   <Text>ID: {group._id}</Text>
                   <Text>Created at: {group.createdAt}</Text>
                   <Text>Description: {group.description}</Text>
-                  <Text>Max users: {group.maxUsers}</Text>
                 </Box>
               </Collapsible.Content>
             </Box>


### PR DESCRIPTION
This should either be in Timeslots or not appear at all